### PR TITLE
Insert NM info in database from start

### DIFF
--- a/cobald-tardis-config/drone.py
+++ b/cobald-tardis-config/drone.py
@@ -78,23 +78,11 @@ if __name__ == "__main__":
         dronesconn.commit()
         print(f"Successfully inserted {args.drone_uuid} for nodemanager {node_label} into database")
 
-    # Insert a nodemanager into db if it doesn't exist yet
+    # Retrieve current allocation on the NM and increase it
     filename_nmdb = os.environ['COBALD_TARDIS_NODEMANAGER_DATABASE']
     print(f'Path to nodemanager database: {filename_nmdb}')
     nmconn = sqlite3.connect(filename_nmdb)
 
-    with nmconn:
-        nmcursor = nmconn.cursor()
-        insert_nm = """
-            INSERT OR IGNORE INTO yarn_nm
-            (name, cpus, allocated_vcores, allocated_memory_mb)
-            VALUES
-            (?, ?, ?, ?)"""
-        # TODO: Remove this hardcoded value and make this configurable
-        nmcursor.execute(insert_nm, (node_label, os.cpu_count(), 1, 1500))
-        nmconn.commit()
-
-    # Retrieve current allocation and increase it
     with lock:
         # Update database
         nmcursor = nmconn.cursor()

--- a/cobald-tardis-config/nodemanager_database.py
+++ b/cobald-tardis-config/nodemanager_database.py
@@ -1,39 +1,129 @@
 import argparse
+import os
+import socket
 import sqlite3
 
+import requests
+
 parser = argparse.ArgumentParser()
-parser.add_argument("path", help="Path to the database.")
-parser.add_argument("--create", help="Create the drones db from scratch.", action="store_true")
-parser.add_argument("--print", help="Print the drones db.", action="store_true")
+parser.add_argument('path', help='Path to the database.')
+parser.add_argument(
+    '--create', help='Create the drones db from scratch.', action='store_true')
+parser.add_argument(
+    '--print', help='Print the drones db.', action='store_true')
+parser.add_argument(
+    '--insert_nm', help='Insert this machine as a nodemanager in the database',
+    action='store_true')
 args = parser.parse_args()
 
+
+class YarnResourceManager(object):
+    def __init__(self, hostname, ip=8088):
+        self.hostname = hostname
+        self.ip = ip
+        self.base = 'http://{HOSTNAME}:{IP}'.format(HOSTNAME=hostname, IP=ip)
+
+    def _get_nodes(self):
+        r = requests.get(self.base + '/ws/v1/cluster/nodes')
+        nodes = []
+        data = r.json()
+        for node in data['nodes']['node']:
+            nodes.append(node['id'])
+        return nodes
+
+    @property
+    def nodes(self):
+        return self._get_nodes()
+
+    def get_resources(self, node):
+        r = requests.get(self.base + '/ws/v1/cluster/nodes/' + node)
+        data = r.json()
+
+        totalresources = data['node']['totalResource']
+
+        return {'id': node,
+                'cores': totalresources['vCores'],
+                'memory': totalresources['memory'], }
+
+    def _get_apps(self):
+        r = requests.get(self.base + '/ws/v1/cluster/apps')
+        data = r.json()
+        apps = []
+        try:
+            for app in data['apps']['app']:
+                id_ = app['id']
+                state = app['state']
+                memory = app['allocatedMB']
+                cpus = app['allocatedVCores']
+                apps.append({'id': id_, 'cpus': cpus,
+                             'memory': memory, 'state': state})
+        except:
+            pass
+        return apps
+
+    @property
+    def apps(self):
+        return self._get_apps()
+
+
 def create_db():
-    sqliteConnection = sqlite3.connect(args.path)
-    sqlite_create_table_query = """CREATE TABLE yarn_nm (
+    sqlconn = sqlite3.connect(args.path)
+    sqlite_create_table_query = '''CREATE TABLE yarn_nm (
                                 name TEXT PRIMARY KEY,
                                 cpus INTEGER NOT NULL,
                                 allocated_vcores INTEGER NOT NULL,
-                                allocated_memory_mb INTEGER NOT NULL);"""
-    cursor = sqliteConnection.cursor()
+                                allocated_memory_mb INTEGER NOT NULL);'''
+    cursor = sqlconn.cursor()
     cursor.execute(sqlite_create_table_query)
-    sqliteConnection.commit()
-    print("SQLite table created")
+    sqlconn.commit()
+    print('SQLite table created')
 
     cursor.close()
-    sqliteConnection.close()
-    print("sqlite connection is closed")
+    sqlconn.close()
+    print('SQLite connection is closed')
+
+
+def insert_nm_in_db(hostname):
+    rm = YarnResourceManager(os.environ['YARN_RESOURCEMANAGER'])
+    sqlconn = sqlite3.connect(args.path)
+    # Insert current nodemanager into the database
+    insert_nm_query = '''
+        INSERT INTO yarn_nm
+        (name, cpus, allocated_vcores, allocated_memory_mb)
+        VALUES
+        (?, ?, ?, ?)'''
+
+    # Retrieve full node address comparing the current hostname with the list
+    # of node addresses in the cluster
+    node_address = next(node for node in rm.nodes if hostname in node)
+    node_data = rm.get_resources(node_address)
+
+    cursor = sqlconn.cursor()
+    cursor.execute(insert_nm_query, (node_data['id'],
+                                     os.cpu_count(),
+                                     node_data['cores'],
+                                     node_data['memory']))
+    sqlconn.commit()
+    print(f'Nodemanager {node_address} added to table yarn_nm')
+
+    cursor.close()
+    sqlconn.close()
+    print('SQLite connection is closed')
+
 
 def print_db():
     sqliteConnection = sqlite3.connect(args.path)
     with sqliteConnection:
         cursor = sqliteConnection.cursor()
-        cursor.execute("SELECT * FROM yarn_nm")
+        cursor.execute('SELECT * FROM yarn_nm')
         for line in cursor.fetchall():
             print(line)
 
-if __name__ == "__main__":
+
+if __name__ == '__main__':
     if args.create:
         create_db()
     elif args.print:
         print_db()
-
+    elif args.insert_nm:
+        insert_nm_in_db(socket.gethostname())

--- a/insert-nodemanager.sh
+++ b/insert-nodemanager.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+SCRIPT=$(readlink -f $BASH_SOURCE[0])
+SCRIPT_DIR=$(dirname $SCRIPT)
+source $SCRIPT_DIR/setup.sh
+
+$PYTHON_BINARY $COBALD_TARDIS_CONFIG_DIR/nodemanager_database.py $COBALD_TARDIS_NODEMANAGER_DATABASE --insert_nm

--- a/run-cobald.sh
+++ b/run-cobald.sh
@@ -6,10 +6,9 @@ source $SCRIPT_DIR/setup.sh
 
 cd $COBALD_TARDIS_CONFIG_DIR
 
-# Recreate databases
-rm -f $COBALD_TARDIS_DRONES_DATABASE $COBALD_TARDIS_NODEMANAGER_DATABASE
+# Recreate drones database
+rm -f $COBALD_TARDIS_DRONES_DATABASE
 $PYTHON_BINARY drones_database.py $COBALD_TARDIS_DRONES_DATABASE --create
-$PYTHON_BINARY nodemanager_database.py $COBALD_TARDIS_NODEMANAGER_DATABASE --create
 
 # Run cobald
 $PYTHON_BINARY -m cobald.daemon cobald.yml 2>&1 | tee $PROJECT_TMP/cobald.log

--- a/run-resourcemanager.sh
+++ b/run-resourcemanager.sh
@@ -4,4 +4,8 @@ SCRIPT=$(readlink -f $BASH_SOURCE[0])
 SCRIPT_DIR=$(dirname $SCRIPT)
 source $SCRIPT_DIR/setup.sh
 
+# Recreate nodemanager database
+rm -f $COBALD_TARDIS_NODEMANAGER_DATABASE
+$PYTHON_BINARY $COBALD_TARDIS_CONFIG_DIR/nodemanager_database.py $COBALD_TARDIS_NODEMANAGER_DATABASE --create
+
 yarn resourcemanager 2>&1 | tee $PROJECT_TMP/resourcemanager-$(hostname).log

--- a/start-nodemanagers.sh
+++ b/start-nodemanagers.sh
@@ -31,6 +31,10 @@ do
     then
         echo "Kill screen sessions on" ${HOSTNAME}
         ssh ${USER}@${HOSTNAME} "killall screen"
+    elif  [ ${MODE} = "insert" ]
+    then
+        echo "Insert nodemanager" ${HOSTNAME} "in database"
+        ssh ${USER}@${HOSTNAME}  "bash ${SCRIPT_DIR}/insert-nodemanager.sh"
     else
         echo "Unknown mode: " ${MODE}
         exit


### PR DESCRIPTION
Moved the logic to insert nodemanagers in the database to the `nodemanager_database.py` file. Now we can insert info of the nodemanager right in the db right after we start it through the `insert-nodemanager.sh` script. For multiple nodemanagers the mode `insert` has been added to `start-nodemanagers.sh` .

As a consequence of this new logic, we can always retrieve the cpu count for any nodemanager when running `run-yarn-monitoring.sh`, thus we can always compute the adjusted `containersCPUUsage` value irrespective of whether we have some drones running or not (because a spark application will start as soon as we have at least 2 cores available in YARN 1 for the application master and the other that actually runs the job)